### PR TITLE
Support date-time for fieldsets

### DIFF
--- a/common/mockData/formatterMockData.ts
+++ b/common/mockData/formatterMockData.ts
@@ -222,6 +222,43 @@ export const JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA = '{\n' +
   '  "type": "object"\n' +
   ' }\n' +
   '}';
+
+export const JSON_SCHEMA_DATE_TIME_FIELD_SETS = '{\n' +
+  ' "schema": {\n' +
+  '  "$schema": "http://json-schema.org/draft-04/schema#",\n' +
+  '  "definition": [\n' +
+  '   {\n' +
+  '    "htmlClass": "col-lg-6",\n' +
+  '    "items": [\n' +
+  '     {\n' +
+  '      "fieldHtmlClass": "date-time-picker json-schema",\n' +
+  '      "key": "arrival_time"\n' +
+  '     }\n' +
+  '    ],\n' +
+  '    "type": "fieldset"\n' +
+  '   }\n' +
+  '  ],\n' +
+  '  "properties": {\n' +
+  '   "arrival_time": {\n' +
+  '    "key": "Arrival Time",\n' +
+  '    "title": "HWC MU Arrival Time (at scene)"\n' +
+  '   }\n' +
+  '  },\n' +
+  '  "title": "EventType Test Data",\n' +
+  '  "type": "object"\n' +
+  ' }\n' +
+  '}';
+
+export const UI_SCHEMA_ELEMENT_DATE_TIME_FIELD_SETS = {
+  "type": "Control",
+  "scope": "#/properties/arrival_time",
+  "label": "HWC MU Arrival Time (at scene)",
+  "options": {
+    "format": "date-time",
+    "display": "date-time"
+  }
+};
+
 export const JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA = '{\n' +
   ' "schema": {\n' +
   '  "definition": [\n' +

--- a/src/generateUISchema.ts
+++ b/src/generateUISchema.ts
@@ -158,8 +158,7 @@ const getUIElement = (key: string, schema: any, fieldSetItem: any = undefined) =
       }
       return getBaseUIObject(key, schema.schema.properties[key].title || '', options);
 
-    case undefined:
-    {
+    case undefined: {
       const dateTimeFormat = getDateTimeControlFormat(key, schema, fieldSetItem);
       if (!isEmptyString(dateTimeFormat)) {
         options = getElementOptions(PropertyFormat.DateTime, dateTimeFormat);

--- a/src/generateUISchema.ts
+++ b/src/generateUISchema.ts
@@ -10,6 +10,7 @@ import {
   isFieldSetTitleWithoutItems, isPropertyKey,
   isSchemaFieldSet, PropertyFormat,
 } from './utils/utils';
+import { isEmptyString } from './utils/stringUtils';
 
 // Enums
 enum SchemaTypes {
@@ -137,16 +138,16 @@ const getUIElement = (key: string, schema: any, fieldSetItem: any = undefined) =
     case SchemaTypes.Number:
       return getBaseUIObject(key, schema.schema.properties[key].title || '');
 
-    case SchemaTypes.String:
-      // eslint-disable-next-line no-case-declarations
+    case SchemaTypes.String: {
       const dateTimeFormat = getDateTimeControlFormat(key, schema, fieldSetItem);
-      if (!isEmpty(dateTimeFormat)) {
+      if (!isEmptyString(dateTimeFormat)) {
         options = getElementOptions(PropertyFormat.DateTime, dateTimeFormat);
       } else if (schema.schema.properties[key].display
         && schema.schema.properties[key].display === ElementDisplay.Header) {
         options = getElementOptions(PropertyFormat.FormLabel);
       }
       return getBaseUIObject(key, schema.schema.properties[key].title || '', options);
+    }
 
     case SchemaTypes.Array:
       if (schema.schema.properties[key].items.enum
@@ -156,6 +157,17 @@ const getUIElement = (key: string, schema: any, fieldSetItem: any = undefined) =
         options = getElementOptions(PropertyFormat.RepeatableField);
       }
       return getBaseUIObject(key, schema.schema.properties[key].title || '', options);
+
+    case undefined:
+    {
+      const dateTimeFormat = getDateTimeControlFormat(key, schema, fieldSetItem);
+      if (!isEmptyString(dateTimeFormat)) {
+        options = getElementOptions(PropertyFormat.DateTime, dateTimeFormat);
+        return getBaseUIObject(key, schema.schema.properties[key].title || '', options);
+      }
+      return undefined;
+    }
+
     default:
       break;
   }

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,3 @@
+export const isEmptyString = (value: string | undefined) => (value === undefined
+  || value === null
+  || value.trim().length === 0);

--- a/test/JsonFormatter.test.tsx
+++ b/test/JsonFormatter.test.tsx
@@ -19,8 +19,11 @@ import {
     COLLECTION_FIELD_HEADER_FAKE_DATA,
     JSON_SCHEMA_INLINE_REQUIRED_PROPERTIES,
     JSON_SCHEMA_INACTIVE_TITLE_MAP_FAKE_DATA,
-    JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA, JSON_SCHEMA_DEFAULT_VALUES,
+    JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA,
+    JSON_SCHEMA_DEFAULT_VALUES,
+    JSON_SCHEMA_DATE_TIME_FIELDSETS, JSON_SCHEMA_DATE_TIME_FIELD_SETS, UI_SCHEMA_ELEMENT_DATE_TIME_FIELD_SETS,
 } from "../common/mockData/formatterMockData";
+import exp = require('node:constants');
 
 describe('JSON Schema validation', () => {
 
@@ -158,6 +161,12 @@ describe('JSON UI Schema generation', () => {
         const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
         const uiSchema = generateUISchema(validSchema);
         expect(uiSchema).toMatchObject(expectedUISchema);
+    });
+
+    it('Validate UI schema date-time fieldset property',  () => {
+        const validSchema = validateJSONSchema(JSON_SCHEMA_DATE_TIME_FIELD_SETS);
+        const uiSchema = generateUISchema(validSchema);
+        expect(uiSchema.elements[0]).toMatchObject(UI_SCHEMA_ELEMENT_DATE_TIME_FIELD_SETS)
     });
 
     it('Generate UI Schema for field sets',  () => {


### PR DESCRIPTION
## Summary
Support date-time for fieldsets

## Fixes
#7  

## Proposed changes
- Support date-time format inside fieldsets in `generateUISchema` function
- Add a test case for this date-time in fieldsets

## Test
Run all the tests `yarn test`, make sure all tests pass 