### PR TITLE
Validate duplicated items for single select

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,7 @@ extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
     'import/prefer-default-export': 'off',
     'react/require-default-props': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
     'no-plusplus': [2, { allowForLoopAfterthoughts: true }]
 },
   root: true,

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ coverage/
 
 # OSX
 .DS_Store
+.idea

--- a/common/mockData/formatterMockData.ts
+++ b/common/mockData/formatterMockData.ts
@@ -222,6 +222,36 @@ export const JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA = '{\n' +
   '  "type": "object"\n' +
   ' }\n' +
   '}';
+
+export const JSON_SCHEMA_DUPLICATED_CHOICES_SINGLE_SELECT_FAKE_DATA = '{\n' +
+  '  "definition": [\n' +
+  '    "single_select"\n' +
+  '  ],\n' +
+  '  "description": "This schema will be used for regression testing in the mobile app",\n' +
+  '  "schema": {\n' +
+  '    "$schema": "http://json-schema.org/draft-04/schema#",\n' +
+  '    "icon_id": "generic_rep",\n' +
+  '    "id": "https://mobile-bash.pamdas.org/api/v1.0/activity/events/schema/eventtype/single_select_query_no_required",\n' +
+  '    "image_url": "https://mobile-bash.pamdas.org/static/generic-black.svg",\n' +
+  '    "properties": {\n' +
+  '      "single_select": {\n' +
+  '        "enum": [\n' +
+  '          "new",\n' +
+  '          "new"\n' +
+  '        ],\n' +
+  '        "enumNames": {\n' +
+  '          "new": "New/Fresh",\n' +
+  '          "old": "New/Fresh"\n' +
+  '        },\n' +
+  '        "title": "I\'m a single select query",\n' +
+  '        "type": "string"\n' +
+  '      }\n' +
+  '    },\n' +
+  '    "title": "String",\n' +
+  '    "type": "object"\n' +
+  '  }\n' +
+  '}';
+
 export const JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA = '{\n' +
   ' "schema": {\n' +
   '  "definition": [\n' +

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-named-as-default */
 // External Dependencies
 import { isEmpty } from 'lodash-es';
 
@@ -20,13 +19,13 @@ export enum ElementDisplay {
 
 export const FIELD_SET = 'fieldset';
 export const HELP_VALUE = 'helpvalue';
-
 export const REQUIRED_PROPERTY = 'required';
 export const CHECKBOXES = 'checkboxes';
 export const INACTIVE_ENUM = 'inactive_enum';
 export const DISABLED_ENUM = 'inactive_titleMap';
 export const STRING_TYPE = 'string';
 export const ARRAY_TYPE = 'array';
+export const ENUM = 'enum';
 
 export const isObject = (item: any) => item instanceof Object;
 
@@ -61,6 +60,7 @@ export const getSchemaValidations = (stringSchema: string) => ({
   hasCheckboxes: hasCheckboxes(stringSchema),
   hasInactiveChoices: hasInactiveChoices(stringSchema),
   hasDisabledChoices: hasDisabledChoices(stringSchema),
+  hasEnums: hasEnums(stringSchema),
 });
 
 export const isArrayProperty = (property: any) => property.type === ARRAY_TYPE && !property.items?.enum
@@ -73,6 +73,8 @@ const hasCheckboxes = (stringSchema: string) => stringSchema.includes(CHECKBOXES
 const hasInactiveChoices = (stringSchema: string) => stringSchema.includes(INACTIVE_ENUM);
 
 const hasDisabledChoices = (stringSchema: string) => stringSchema.includes(DISABLED_ENUM);
+
+const hasEnums = (stringSchema: string) => stringSchema.includes(ENUM);
 
 export const isInactiveChoice = (item: any) => item.type === STRING_TYPE
  && item.enum?.length > 0 && item.inactive_enum?.length > 0;

--- a/test/JsonFormatter.test.tsx
+++ b/test/JsonFormatter.test.tsx
@@ -4,8 +4,8 @@ import jsonSchemaFieldSets from "../common/mockData/jsonSchemaFielSetMock.json";
 import expectedSchema from "../common/mockData/jsonSchemaExpectedMock.json";
 import expectedUISchema from "../common/mockData/uiSchemaExpectedMock.json";
 import expectedFieldSetUISchema from "../common/mockData/uiSchemaFielSetExpectedMock.json";
-import { validateJSONSchema } from "../src/validateJsonSchema";
-import { generateUISchema } from "../src/generateUISchema";
+import { validateJSONSchema } from "../src";
+import { generateUISchema } from "../src";
 import {
     JSON_SCHEMA_ID_$SCHEMA_FAKE_DATA,
     JSON_SCHEMA_EMPTY_CHOICES_FAKE_DATA,
@@ -22,11 +22,9 @@ import {
     JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA,
     JSON_SCHEMA_DEFAULT_VALUES,
     JSON_SCHEMA_DUPLICATED_CHOICES_SINGLE_SELECT_FAKE_DATA,
-    JSON_SCHEMA_DATE_TIME_FIELDSETS,
     JSON_SCHEMA_DATE_TIME_FIELD_SETS,
     UI_SCHEMA_ELEMENT_DATE_TIME_FIELD_SETS,
 } from "../common/mockData/formatterMockData";
-import exp = require('node:constants');
 
 describe('JSON Schema validation', () => {
 

--- a/test/JsonFormatter.test.tsx
+++ b/test/JsonFormatter.test.tsx
@@ -19,7 +19,9 @@ import {
     COLLECTION_FIELD_HEADER_FAKE_DATA,
     JSON_SCHEMA_INLINE_REQUIRED_PROPERTIES,
     JSON_SCHEMA_INACTIVE_TITLE_MAP_FAKE_DATA,
-    JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA, JSON_SCHEMA_DEFAULT_VALUES,
+    JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA,
+    JSON_SCHEMA_DEFAULT_VALUES,
+    JSON_SCHEMA_DUPLICATED_CHOICES_SINGLE_SELECT_FAKE_DATA,
 } from "../common/mockData/formatterMockData";
 
 describe('JSON Schema validation', () => {
@@ -78,6 +80,10 @@ describe('JSON Schema validation', () => {
     it('Validate remove disabled fieldset titleMap choices',  () => {
         const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA);
         expect(validSchema.schema.properties.reportorigin.items.enum).not.toContain('phot_evidence_collected');
+    });
+
+    it('Validate duplicated items in single select',  () => {
+        expect(() => validateJSONSchema(JSON_SCHEMA_DUPLICATED_CHOICES_SINGLE_SELECT_FAKE_DATA)).toThrow('Duplicated items');
     });
 
     it('Format schema definition location',  () => {


### PR DESCRIPTION
## Summary
Validate duplicated items for single-select

## Fixes
#9  

## Proposed changes
- Add utility functions to validate if the current property has items
- The rest of the code was added previously
- Add a test case to validate duplicated items
- Add `.idea` to gitignore 
- Disable `@typescript-eslint/no-explicit-any` rule in linter

## Test
- Run all the tests `yarn test`
- Make sure all tests pass 