### PR TITLE
Into the unknown

### DIFF
--- a/ jest.config.js
+++ b/ jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,18 +1,27 @@
 /* eslint-env node */
 module.exports = {
-extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
-  parser: '@typescript-eslint/parser',
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 13,
-    project: './tsconfig.json',
-    sourceType: 'module',
+    project: "./tsconfig.eslint.json",
+    tsconfigRootDir: __dirname,
+    sourceType: "module",
   },
-  plugins: ['@typescript-eslint'],
+  overrides: [
+    {
+      files: ['test/**/*.{ts,tsx}'],
+      parserOptions: {
+        project: './tsconfig.test.json',
+      },
+    },
+  ],
+  plugins: ["@typescript-eslint"],
   rules: {
-    'import/prefer-default-export': 'off',
-    'react/require-default-props': 'off',
-    '@typescript-eslint/no-use-before-define': 'off',
-    'no-plusplus': [2, { allowForLoopAfterthoughts: true }]
-},
+    "import/prefer-default-export": "off",
+    "react/require-default-props": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "no-plusplus": [2, { allowForLoopAfterthoughts: true }],
+  },
   root: true,
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # React Native JSONForms Formatter
+
 ![Build Status][ci-url]
 
 [ci-url]: https://github.com/PADAS/react-native-jsonforms-formatter/actions/workflows/npm-build.yml/badge.svg
@@ -22,6 +23,7 @@ npm install --save react-native-jsonforms-formatter
 ```
 
 ## Usage
+
 The library provides two main functions: `validateJSONSchema` and `generateUISchema`.
 
 ### Validating JSONSchema
@@ -29,7 +31,7 @@ The library provides two main functions: `validateJSONSchema` and `generateUISch
 You can use the `validateJSONSchema` function to validate a JSONSchema string:
 
 ```typescript
-import { validateJSONSchema } from 'react-native-jsonforms-formatter';
+import { validateJSONSchema } from "react-native-jsonforms-formatter";
 
 const stringSchema = `
 {
@@ -47,16 +49,17 @@ const stringSchema = `
 }
 `;
 
-const jsonSchema = validateJSONSchema(stringSchema);  
+const jsonSchema = validateJSONSchema(stringSchema);
 ```
 
 The `validateJSONSchema` function returns a valid JSONSchema object if the input string is a valid JSONSchema. If the input is not valid, it will throw an error.
 
 ### Generating UISchema
+
 You can use the `generateUISchema` function to generate a UISchema object from a valid JSONSchema:
 
 ```typescript
-import { generateUISchema } from 'react-native-jsonforms-formatter';
+import { generateUISchema } from "react-native-jsonforms-formatter";
 
 const uiSchema = generateUISchema(jsonSchema);
 ```
@@ -64,13 +67,17 @@ const uiSchema = generateUISchema(jsonSchema);
 The `generateUISchema` function returns a `UISchema` object that can be used with the ReactNative JSONForms library.
 
 ## Putting it all together
+
 Here's an example of how you can use the library in a ReactNative application:
 
 ```typescript
-import React from 'react';
-import { JsonForms } from '@jsonforms/react-native';
-import { validateJSONSchema, generateUISchema } from 'react-native-jsonforms-formatter';
-import { RNRenderers, RNCells } from '@jsonforms/react-native-renderers';
+import { JsonForms } from "@jsonforms/react-native";
+import { RNCells, RNRenderers } from "@jsonforms/react-native-renderers";
+import React from "react";
+import {
+  generateUISchema,
+  validateJSONSchema,
+} from "react-native-jsonforms-formatter";
 
 const stringSchema = `
 {
@@ -92,7 +99,7 @@ const jsonSchema = validateJSONSchema(stringSchema);
 const uiSchema = generateUISchema(jsonSchema);
 
 const App = () => {
-  const [data, setData] = React.useState({ name: 'John Doe', age: 30 });
+  const [data, setData] = React.useState({ name: "John Doe", age: 30 });
 
   return (
     <JsonForms
@@ -110,6 +117,7 @@ export default App;
 ```
 
 ## Contributors
+
 Contributions are welcome! If you find a bug or have a feature request, please open an issue.
 
 <a href="https://github.com/PADAS/react-native-jsonforms-formatter/graphs/contributors">
@@ -117,4 +125,5 @@ Contributions are welcome! If you find a bug or have a feature request, please o
 </a>
 
 ## Licensing
+
 A copy of the license is available in the repository's [LICENSE](LICENSE) file.

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', {targets: {node: 'current'}}],
-    '@babel/preset-typescript',
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-typescript",
   ],
 };

--- a/extJestSetup.js
+++ b/extJestSetup.js
@@ -1,3 +1,2 @@
-import * as matchers from 'jest-extended';
+import * as matchers from "jest-extended";
 expect.extend(matchers);
-

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npx webpack",
     "clean": "rm -rf dist",
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
+    "lint:test": "eslint 'test/**/*.{ts,tsx}'",
     "test": "jest test/.*\\.test\\..* --coverage",
     "typecheck": "tsc -b"
   },

--- a/src/generateUISchema.ts
+++ b/src/generateUISchema.ts
@@ -19,7 +19,7 @@ enum SchemaTypes {
   Array = 'array',
 }
 
-const getBaseUIObject = (key: string, title: string, options: any = {}) => (
+const getBaseUIObject = (key: string, title: string, options: unknown = {}) => (
   {
     type: 'Control',
     scope: `#/properties/${key}`,
@@ -27,10 +27,10 @@ const getBaseUIObject = (key: string, title: string, options: any = {}) => (
     ...options && { options },
   });
 
-const getDateTimeControlFormat = (key: string, jsonSchema: any, fieldSetItem: any = undefined) => {
+const getDateTimeControlFormat = (key: string, jsonSchema: unknown, fieldSetItem: unknown = undefined) => {
   try {
     const definitionObject = fieldSetItem
-      || jsonSchema.definition.find((object: any) => (object.key === key));
+      || jsonSchema.definition.find((object: unknown) => (object.key === key));
 
     if (definitionObject.fieldHtmlClass === 'date-time-picker json-schema'
       || (definitionObject && (definitionObject.type || '') === 'datetime')) {
@@ -49,7 +49,7 @@ const getDateTimeControlFormat = (key: string, jsonSchema: any, fieldSetItem: an
   return undefined;
 };
 
-export const generateUISchema = (schema: any) => {
+export const generateUISchema = (schema: unknown) => {
   const elements: Object[] = [];
 
   if (isSchemaFieldSet(schema.definition)) {
@@ -68,10 +68,10 @@ export const generateUISchema = (schema: any) => {
   };
 };
 
-const getFieldSetsElements = (schema: any) => {
+const getFieldSetsElements = (schema: unknown) => {
   const elements: Object[] = [];
 
-  schema.definition.forEach((item: any) => {
+  schema.definition.forEach((item: unknown) => {
     if (typeof item === 'string') {
       elements.push(getBaseUIObject(item, schema.schema.properties[item].title || ''));
     } else if (item instanceof Object) {
@@ -91,7 +91,7 @@ const getFieldSetsElements = (schema: any) => {
               getElementOptions(PropertyFormat.FormLabel),
             ));
           }
-          item.items.forEach((value: any) => {
+          item.items.forEach((value: unknown) => {
             if (value instanceof Object) {
               const element = getUIElement(value.key || '', schema, value);
               if (element) {
@@ -132,7 +132,7 @@ const getElementOptions = (format: string = '', display: string = '') => {
   return options;
 };
 
-const getUIElement = (key: string, schema: any, fieldSetItem: any = undefined) => {
+const getUIElement = (key: string, schema: unknown, fieldSetItem: unknown = undefined) => {
   let options = {};
   switch (schema.schema.properties[key].type as SchemaTypes) {
     case SchemaTypes.Number:

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,29 +27,29 @@ export const STRING_TYPE = 'string';
 export const ARRAY_TYPE = 'array';
 export const ENUM = 'enum';
 
-export const isObject = (item: any) => item instanceof Object;
+export const isObject = (item: unknown) => item instanceof Object;
 
-export const isString = (item: any) => typeof item === STRING_TYPE;
-export const isSchemaFieldSet = (definition: any[]) => {
+export const isString = (item: unknown) => typeof item === STRING_TYPE;
+export const isSchemaFieldSet = (definition: unknown[]) => {
   if (definition.length === 0) {
     return false;
   }
-  const fieldSet = definition.find((item: any) => isObject(item)
+  const fieldSet = definition.find((item: unknown) => isObject(item)
     && item && (item.type || '') === FIELD_SET);
   return fieldSet !== undefined;
 };
 
-export const isFieldSetTitle = (item: any) => isObject(item) && item.type === FIELD_SET
+export const isFieldSetTitle = (item: unknown) => isObject(item) && item.type === FIELD_SET
   && !isEmpty(item.title);
 
-export const isFieldSetTitleWithoutItems = (item: any) => isObject(item) && item.type === FIELD_SET
+export const isFieldSetTitleWithoutItems = (item: unknown) => isObject(item) && item.type === FIELD_SET
   && item.items.length === 0 && !isEmpty(item.title);
 
-export const isFieldSet = (item: any) => isObject(item) && item.type === FIELD_SET && item.items.length > 0;
+export const isFieldSet = (item: unknown) => isObject(item) && item.type === FIELD_SET && item.items.length > 0;
 
-export const isCheckbox = (item: any) => isObject(item) && item.type === CHECKBOXES;
+export const isCheckbox = (item: unknown) => isObject(item) && item.type === CHECKBOXES;
 
-export const isPropertyKey = (item: any) => !isEmpty(item.key);
+export const isPropertyKey = (item: unknown) => !isEmpty(item.key);
 
 export const getFieldSetTitleKey = (title: string) => {
   const key = title.toLowerCase().replace(/[\s\\/\\%]/gi, '_');
@@ -63,10 +63,10 @@ export const getSchemaValidations = (stringSchema: string) => ({
   hasEnums: hasEnums(stringSchema),
 });
 
-export const isArrayProperty = (property: any) => property.type === ARRAY_TYPE && !property.items?.enum
+export const isArrayProperty = (property: unknown) => property.type === ARRAY_TYPE && !property.items?.enum
 && !property.items?.enumNames;
 
-export const isRequiredProperty = (property: any) => property.required === 'true' || property.required > 0;
+export const isRequiredProperty = (property: unknown) => property.required === 'true' || property.required > 0;
 
 const hasCheckboxes = (stringSchema: string) => stringSchema.includes(CHECKBOXES);
 
@@ -76,10 +76,10 @@ const hasDisabledChoices = (stringSchema: string) => stringSchema.includes(DISAB
 
 const hasEnums = (stringSchema: string) => stringSchema.includes(ENUM);
 
-export const isInactiveChoice = (item: any) => item.type === STRING_TYPE
+export const isInactiveChoice = (item: unknown) => item.type === STRING_TYPE
  && item.enum?.length > 0 && item.inactive_enum?.length > 0;
 
-export const isDisabledChoice = (item: any) => isObject(item) && item.type === CHECKBOXES && item.inactive_titleMap?.length > 0
+export const isDisabledChoice = (item: unknown) => isObject(item) && item.type === CHECKBOXES && item.inactive_titleMap?.length > 0
   && item.titleMap?.length > 0;
 
 export const hasEnumDuplicatedItems = (options: string[]) => (new Set(options).size !== options.length);

--- a/src/validateJsonSchema.ts
+++ b/src/validateJsonSchema.ts
@@ -31,7 +31,7 @@ const maxParamRegex = /"maximum"(?:[^\\"]|\\\\|\\")*"\d+\.*\d*"/g;
 const doubleSingleQuotesRegex = /"(?=[^"]*(?:"[^"]*)?$)/g;
 
 const getSchemaForCheckbox = (
-  definition: any,
+  definition: unknown,
   title: string,
   required: boolean,
   defaultValue: string,
@@ -42,8 +42,8 @@ const getSchemaForCheckbox = (
   ...required && { required },
   title: title || definition.title,
   items: {
-    enum: definition.titleMap.map((item: any) => item.value),
-    enumNames: definition.titleMap.map((item: any) => item.name),
+    enum: definition.titleMap.map((item: unknown) => item.value),
+    enumNames: definition.titleMap.map((item: unknown) => item.name),
   },
   ...defaultValue && { default: defaultValue },
 });
@@ -56,9 +56,9 @@ const getTitleProperty = (title: string) => ({
   title,
 });
 
-const getPropertyVisibility = (property: any) => property?.isHidden || false;
+const getPropertyVisibility = (property: unknown) => property?.isHidden || false;
 
-const cleanUpRequiredProperty = (schema: any) => {
+const cleanUpRequiredProperty = (schema: unknown) => {
   const requiredProperties = [];
 
   // Iterate over the properties to get clean enum data
@@ -81,7 +81,7 @@ const cleanUpRequiredProperty = (schema: any) => {
   return schema;
 };
 
-const formatDefinitionInSchema = (schema: any) => {
+const formatDefinitionInSchema = (schema: unknown) => {
   if (schema.schema.definition) {
     const { definition } = schema.schema;
     delete schema.schema.definition;
@@ -91,8 +91,8 @@ const formatDefinitionInSchema = (schema: any) => {
   return schema;
 };
 
-const formatSchemaRepeatableFieldLayout = (schema: any) => {
-  const properties: any = {};
+const formatSchemaRepeatableFieldLayout = (schema: unknown) => {
+  const properties: unknown = {};
   let headerCount = 0;
 
   // eslint-disable-next-line no-restricted-syntax
@@ -116,10 +116,10 @@ const formatSchemaRepeatableFieldLayout = (schema: any) => {
 };
 
 // eslint-disable-next-line max-len
-const cleanUpInactiveEnumChoice = (property: any) => property.enum.filter((choice: any) => !property.inactive_enum.includes(choice));
+const cleanUpInactiveEnumChoice = (property: unknown) => property.enum.filter((choice: unknown) => !property.inactive_enum.includes(choice));
 
 // eslint-disable-next-line max-len
-const cleanUpDisabledEnumChoice = (definitionItem: any) => definitionItem.titleMap.filter((item: any) => !definitionItem.inactive_titleMap.includes(item.value));
+const cleanUpDisabledEnumChoice = (definitionItem: unknown) => definitionItem.titleMap.filter((item: unknown) => !definitionItem.inactive_titleMap.includes(item.value));
 
 const validateJSON = (stringSchema: string) => {
   if (stringSchema.match(specialCharactersInKey) !== null) {
@@ -140,7 +140,7 @@ const validateJSON = (stringSchema: string) => {
   return stringSchema;
 };
 
-const cleanUpJTD = (validations: any, schema: any) => {
+const cleanUpJTD = (validations: unknown, schema: unknown) => {
   if (isSchemaFieldSet(schema.definition)) {
     validateFieldSetDefinition(validations, schema);
   } else if (schema.definition?.length > 0) {
@@ -150,7 +150,7 @@ const cleanUpJTD = (validations: any, schema: any) => {
   }
 };
 
-const validateFieldSetDefinition = (validations: any, schema: any) => {
+const validateFieldSetDefinition = (validations: unknown, schema: unknown) => {
   for (const item of schema.definition) {
     switch (true) {
       case isString(item):
@@ -175,7 +175,7 @@ const validateFieldSetDefinition = (validations: any, schema: any) => {
   }
 };
 
-const validateDefinition = (validations: any, item: any, schema: any, parentItem?: any) => {
+const validateDefinition = (validations: unknown, item: unknown, schema: unknown, parentItem?: unknown) => {
   const { hasCheckboxes, hasDisabledChoices } = validations;
   // Set property visibility
   if (isString(item) && schema.schema.properties[item]) {
@@ -214,7 +214,7 @@ const validateDefinition = (validations: any, item: any, schema: any, parentItem
   }
 };
 
-const validateSchema = (validations: any, schema: any) => {
+const validateSchema = (validations: unknown, schema: unknown) => {
   const { hasInactiveChoices, hasEnums } = validations;
   if (hasInactiveChoices) {
     for (const key of Object.keys(schema.schema.properties)) {

--- a/test/JsonFormatter.test.tsx
+++ b/test/JsonFormatter.test.tsx
@@ -1,168 +1,175 @@
 // Internal Dependencies
-import jsonSchema from "../common/mockData/jsonSchemaMock.json";
-import jsonSchemaFieldSets from "../common/mockData/jsonSchemaFielSetMock.json";
+import {
+  COLLECTION_FIELD_HEADER_FAKE_DATA,
+  FIELD_SET_HEADER_FAKE_DATA,
+  JSON_SCHEMA_COLLECTION_FIELD_FAKE_DATA,
+  JSON_SCHEMA_DEFAULT_VALUES,
+  JSON_SCHEMA_EMPTY_CHOICES_FAKE_DATA,
+  JSON_SCHEMA_FIELD_SETS_FAKE_DATA,
+  JSON_SCHEMA_ID_$SCHEMA_FAKE_DATA,
+  JSON_SCHEMA_INACTIVE_CHOICES_FAKE_DATA,
+  JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA,
+  JSON_SCHEMA_INACTIVE_TITLE_MAP_FAKE_DATA,
+  JSON_SCHEMA_INLINE_REQUIRED_PROPERTIES,
+  JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA,
+  JSON_SCHEMA_INVALID_DOUBLE_QUOTES_FAKE_DATA,
+  JSON_SCHEMA_SPECIAL_CHARS_FAKE_DATA,
+} from "../common/mockData/formatterMockData"
 import expectedSchema from "../common/mockData/jsonSchemaExpectedMock.json";
+import jsonSchemaFieldSets from "../common/mockData/jsonSchemaFielSetMock.json";
+import jsonSchema from "../common/mockData/jsonSchemaMock.json";
 import expectedUISchema from "../common/mockData/uiSchemaExpectedMock.json";
 import expectedFieldSetUISchema from "../common/mockData/uiSchemaFielSetExpectedMock.json";
-import { validateJSONSchema } from "../src/validateJsonSchema";
 import { generateUISchema } from "../src/generateUISchema";
-import {
-    JSON_SCHEMA_ID_$SCHEMA_FAKE_DATA,
-    JSON_SCHEMA_EMPTY_CHOICES_FAKE_DATA,
-    JSON_SCHEMA_INVALID_DOUBLE_QUOTES_FAKE_DATA,
-    JSON_SCHEMA_SPECIAL_CHARS_FAKE_DATA,
-    JSON_SCHEMA_INACTIVE_CHOICES_FAKE_DATA,
-    JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA,
-    JSON_SCHEMA_FIELD_SETS_FAKE_DATA,
-    FIELD_SET_HEADER_FAKE_DATA,
-    JSON_SCHEMA_COLLECTION_FIELD_FAKE_DATA,
-    COLLECTION_FIELD_HEADER_FAKE_DATA,
-    JSON_SCHEMA_INLINE_REQUIRED_PROPERTIES,
-    JSON_SCHEMA_INACTIVE_TITLE_MAP_FAKE_DATA,
-    JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA, JSON_SCHEMA_DEFAULT_VALUES,
-} from "../common/mockData/formatterMockData";
+import { validateJSONSchema } from "../src/validateJsonSchema";
 
-describe('JSON Schema validation', () => {
+describe("JSON Schema validation", () => {
+  it("Special chars should throw an exception", () => {
+    expect(() => {
+      validateJSONSchema(JSON_SCHEMA_SPECIAL_CHARS_FAKE_DATA);
+    }).toThrowError("Special characters not supported in JSON Schema");
+  });
 
-    it('Special chars should throw an exception',  () => {
-        expect(() => { validateJSONSchema(JSON_SCHEMA_SPECIAL_CHARS_FAKE_DATA) }).toThrowError('Special characters not supported in JSON Schema');
-    });
+  it("Validate invalid double quotes", () => {
+    expect(validateJSONSchema(JSON_SCHEMA_INVALID_DOUBLE_QUOTES_FAKE_DATA).toString).not.toContain(/([“”])/g);
+  });
 
-    it('Validate invalid double quotes',  () => {
-        expect(validateJSONSchema(JSON_SCHEMA_INVALID_DOUBLE_QUOTES_FAKE_DATA).toString).not.toContain(/([“”])/g);
-    });
+  it("Validate empty choices", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_EMPTY_CHOICES_FAKE_DATA).toString;
+    expect(validSchema).not.toContain(/\"enum\"\n*\s*\:\n*\s*\[\n*\s*\]/g);
+    expect(validSchema).not.toContain(/\"enumNames\"\n*\s*\:\n*\s*\{\n*\s*\}/g);
+    expect(validSchema).not.toContain(/\"titleMap\"\n*\s*\:\n*\s*\[\n*\s*\]/g);
+  });
 
-    it('Validate empty choices',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_EMPTY_CHOICES_FAKE_DATA).toString;
-        expect(validSchema).not.toContain(/\"enum\"\n*\s*\:\n*\s*\[\n*\s*\]/g);
-        expect(validSchema).not.toContain(/\"enumNames\"\n*\s*\:\n*\s*\{\n*\s*\}/g);
-        expect(validSchema).not.toContain(/\"titleMap\"\n*\s*\:\n*\s*\[\n*\s*\]/g);
-    });
+  it("Validate remove $schema and id properties", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_ID_$SCHEMA_FAKE_DATA);
+    expect(validSchema.schema.$schema).toBeUndefined();
+    expect(validSchema.schema.id).toBeUndefined();
+  });
 
-    it('Validate remove $schema and id properties',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_ID_$SCHEMA_FAKE_DATA);
-        expect(validSchema.schema.$schema).toBeUndefined();
-        expect(validSchema.schema.id).toBeUndefined();
-    });
+  it("Validate field default values", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_DEFAULT_VALUES);
+    expect(validSchema.schema.properties.test_one_date.default).toBe("2023-08-14 15:15");
+    expect(validSchema.schema.properties.test_two_string.default).toBe("Test 2");
+    expect(validSchema.schema.properties.test_three_number.default).toBe(25);
+    expect(validSchema.schema.properties.test_four_number.default).toBe(6);
+    expect(validSchema.schema.properties.test_five_enumString.default).toBe("behavior1");
+    expect(validSchema.schema.properties.test_six_enum_dictionary.default).toBe("testone");
+    expect(validSchema.schema.properties.testseven.default).toMatchObject(["testseventhree"]);
+    expect(validSchema.schema.properties.test_eight_checkbox_query.default).toMatchObject([
+      "9b5cb19e-b7bd-4fa8-9263-8e34502e35ca",
+    ]);
+    expect(validSchema.schema.properties.test_nine_dropdown_query.default).toBe("9b5cb19e-b7bd-4fa8-9263-8e34502e35ca");
+    expect(validSchema.schema.properties.testElevenArrayTest.default).toMatchObject([
+      {
+        "test_array_number": 1,
+        "test_array_string": "string",
+      },
+    ]);
+    expect(validSchema.schema.properties.test_fourteen_textarea.default).toBe("Test 14");
+  });
 
-    it('Validate field default values',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_DEFAULT_VALUES);
-        expect(validSchema.schema.properties.test_one_date.default).toBe('2023-08-14 15:15');
-        expect(validSchema.schema.properties.test_two_string.default).toBe('Test 2');
-        expect(validSchema.schema.properties.test_three_number.default).toBe(25);
-        expect(validSchema.schema.properties.test_four_number.default).toBe(6);
-        expect(validSchema.schema.properties.test_five_enumString.default).toBe('behavior1');
-        expect(validSchema.schema.properties.test_six_enum_dictionary.default).toBe('testone');
-        expect(validSchema.schema.properties.testseven.default).toMatchObject(['testseventhree']);
-        expect(validSchema.schema.properties.test_eight_checkbox_query.default).toMatchObject(['9b5cb19e-b7bd-4fa8-9263-8e34502e35ca']);
-        expect(validSchema.schema.properties.test_nine_dropdown_query.default).toBe('9b5cb19e-b7bd-4fa8-9263-8e34502e35ca');
-        expect(validSchema.schema.properties.testElevenArrayTest.default).toMatchObject([
-            {
-                "test_array_number": 1,
-                "test_array_string": "string"
-            }
-        ]);
-        expect(validSchema.schema.properties.test_fourteen_textarea.default).toBe('Test 14');
-    });
+  it("Validate remove inactive enum choices", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_CHOICES_FAKE_DATA);
+    expect(validSchema.schema.properties.invasivespecies_urgency.enum).not.toContain("test");
+  });
 
-    it('Validate remove inactive enum choices',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_CHOICES_FAKE_DATA);
-        expect(validSchema.schema.properties.invasivespecies_urgency.enum).not.toContain('test');
-    });
+  it("Validate remove disabled titleMap choices", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_TITLE_MAP_FAKE_DATA);
+    expect(validSchema.schema.properties.behavior.items.enum).not.toContain("phot_evidence_collected");
+  });
 
-    it('Validate remove disabled titleMap choices',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_TITLE_MAP_FAKE_DATA);
-        expect(validSchema.schema.properties.behavior.items.enum).not.toContain('phot_evidence_collected');
-    });
+  it("Validate remove disabled fieldset titleMap choices", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA);
+    expect(validSchema.schema.properties.reportorigin.items.enum).not.toContain("phot_evidence_collected");
+  });
 
-    it('Validate remove disabled fieldset titleMap choices',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA);
-        expect(validSchema.schema.properties.reportorigin.items.enum).not.toContain('phot_evidence_collected');
-    });
+  it("Format schema definition location", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA);
+    expect(validSchema.schema.definition).toBeUndefined();
+    expect(validSchema.definition).not.toBeUndefined();
+  });
 
-    it('Format schema definition location',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA);
-        expect(validSchema.schema.definition).toBeUndefined();
-        expect(validSchema.definition).not.toBeUndefined();
-    });
+  it("Format readonly properties for field set headers", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_FIELD_SETS_FAKE_DATA);
+    expect(validSchema.schema.properties["fieldset__title_fieldset_title"]).toMatchObject(
+      FIELD_SET_HEADER_FAKE_DATA.fieldset__title_fieldset_title,
+    );
+    expect(validSchema.schema.properties["fieldset__title_fieldset_number_title"]).toMatchObject(
+      FIELD_SET_HEADER_FAKE_DATA.fieldset__title_fieldset_number_title,
+    );
+  });
 
-    it('Format readonly properties for field set headers',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_FIELD_SETS_FAKE_DATA);
-        expect(validSchema.schema.properties['fieldset__title_fieldset_title']).toMatchObject(FIELD_SET_HEADER_FAKE_DATA.fieldset__title_fieldset_title);
-        expect(validSchema.schema.properties['fieldset__title_fieldset_number_title']).toMatchObject(FIELD_SET_HEADER_FAKE_DATA.fieldset__title_fieldset_number_title);
-    });
+  it("Format collection field headers", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_COLLECTION_FIELD_FAKE_DATA);
+    expect(validSchema.schema.properties["help_value_0"]).toMatchObject(COLLECTION_FIELD_HEADER_FAKE_DATA.help_value_0);
+  });
 
-    it('Format collection field headers',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_COLLECTION_FIELD_FAKE_DATA);
-        expect(validSchema.schema.properties['help_value_0']).toMatchObject(COLLECTION_FIELD_HEADER_FAKE_DATA.help_value_0);
-    });
+  it("Validate field visibility", () => {
+    const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
+    expect(validSchema.schema.properties["string"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["paragraph"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["number_no_min_max"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["number_with_min"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["number_with_max"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["number_with_min_and_max"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["single_select"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["single_select_choices"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["collection"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["calendar"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["checkbox_static_choice"].isHidden).toBe(false);
+    expect(validSchema.schema.properties["checkbox_query"].isHidden).toBe(false);
+  });
 
-    it('Validate field visibility',  () => {
-        const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
-        expect(validSchema.schema.properties['string'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['paragraph'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['number_no_min_max'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['number_with_min'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['number_with_max'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['number_with_min_and_max'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['single_select'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['single_select_choices'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['collection'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['calendar'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['checkbox_static_choice'].isHidden).toBe(false);
-        expect(validSchema.schema.properties['checkbox_query'].isHidden).toBe(false);
-    });
+  it("Format required inline properties", () => {
+    const validSchema = validateJSONSchema(JSON_SCHEMA_INLINE_REQUIRED_PROPERTIES);
+    expect(validSchema.schema.properties["string"].required).toBeUndefined();
+    expect(validSchema.schema.properties["paragraph"].required).toBeUndefined();
+    expect(validSchema.schema.properties["number_no_min_max"].required).toBeUndefined();
+    expect(validSchema.schema.properties["number_with_min"].required).toBeUndefined();
+    expect(validSchema.schema.properties["number_with_max"].required).toBeUndefined();
+    expect(validSchema.schema.properties["number_with_min_and_max"].required).toBeUndefined();
+    expect(validSchema.schema.properties["single_select"].required).toBeUndefined();
+    expect(validSchema.schema.properties["single_select_choices"].required).toBeUndefined();
+    expect(validSchema.schema.properties["collection"].required).toBeUndefined();
+    expect(validSchema.schema.properties["collection"].items.properties["ItemConfiscated"].required).toBeUndefined();
+    expect(validSchema.schema.properties["collection"].items.properties["ItemNumber"].required).toBeUndefined();
+    expect(validSchema.schema.properties["calendar"].required).toBeUndefined();
+    expect(validSchema.schema.properties["checkbox_static_choice"].required).toBeUndefined();
+    expect(validSchema.schema.properties["checkbox_query"].required).toBeUndefined();
+    // @ts-ignore
+    expect(validSchema.schema.required).toIncludeAllMembers([
+      "string",
+      "paragraph",
+      "number_no_min_max",
+      "number_with_min",
+      "number_with_max",
+      "number_with_min_and_max",
+      "single_select",
+      "single_select_choices",
+      "collection",
+      "calendar",
+      "checkbox_static_choice",
+      "checkbox_query",
+    ]);
+  });
 
-    it('Format required inline properties',  () => {
-        const validSchema = validateJSONSchema(JSON_SCHEMA_INLINE_REQUIRED_PROPERTIES);
-        expect(validSchema.schema.properties['string'].required).toBeUndefined();
-        expect(validSchema.schema.properties['paragraph'].required).toBeUndefined();
-        expect(validSchema.schema.properties['number_no_min_max'].required).toBeUndefined();
-        expect(validSchema.schema.properties['number_with_min'].required).toBeUndefined();
-        expect(validSchema.schema.properties['number_with_max'].required).toBeUndefined();
-        expect(validSchema.schema.properties['number_with_min_and_max'].required).toBeUndefined();
-        expect(validSchema.schema.properties['single_select'].required).toBeUndefined();
-        expect(validSchema.schema.properties['single_select_choices'].required).toBeUndefined();
-        expect(validSchema.schema.properties['collection'].required).toBeUndefined();
-        expect(validSchema.schema.properties['collection'].items.properties['ItemConfiscated'].required).toBeUndefined();
-        expect(validSchema.schema.properties['collection'].items.properties['ItemNumber'].required).toBeUndefined();
-        expect(validSchema.schema.properties['calendar'].required).toBeUndefined();
-        expect(validSchema.schema.properties['checkbox_static_choice'].required).toBeUndefined();
-        expect(validSchema.schema.properties['checkbox_query'].required).toBeUndefined();
-        // @ts-ignore
-        expect(validSchema.schema.required).toIncludeAllMembers([
-            'string',
-            'paragraph',
-            'number_no_min_max',
-            'number_with_min',
-            'number_with_max',
-            'number_with_min_and_max',
-            'single_select',
-            'single_select_choices',
-            'collection',
-            'calendar',
-            'checkbox_static_choice',
-            'checkbox_query',
-        ]);
-    });
-
-    it('Validate schema validator should match expected json schema',  () => {
-        const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
-        expect(validSchema).toMatchObject(expectedSchema);
-    });
+  it("Validate schema validator should match expected json schema", () => {
+    const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
+    expect(validSchema).toMatchObject(expectedSchema);
+  });
 });
 
-describe('JSON UI Schema generation', () => {
+describe("JSON UI Schema generation", () => {
+  it("Generate UI Schema for all renderers", () => {
+    const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
+    const uiSchema = generateUISchema(validSchema);
+    expect(uiSchema).toMatchObject(expectedUISchema);
+  });
 
-    it('Generate UI Schema for all renderers',  () => {
-        const validSchema = validateJSONSchema(JSON.stringify(jsonSchema));
-        const uiSchema = generateUISchema(validSchema);
-        expect(uiSchema).toMatchObject(expectedUISchema);
-    });
-
-    it('Generate UI Schema for field sets',  () => {
-        const validSchema = validateJSONSchema(JSON.stringify(jsonSchemaFieldSets));
-        const uiSchema = generateUISchema(validSchema);
-        expect(uiSchema).toMatchObject(expectedFieldSetUISchema);
-    });
+  it("Generate UI Schema for field sets", () => {
+    const validSchema = validateJSONSchema(JSON.stringify(jsonSchemaFieldSets));
+    const uiSchema = generateUISchema(validSchema);
+    expect(uiSchema).toMatchObject(expectedFieldSetUISchema);
+  });
 });

--- a/test/JsonFormatter.test.tsx
+++ b/test/JsonFormatter.test.tsx
@@ -3,7 +3,9 @@ import {
   COLLECTION_FIELD_HEADER_FAKE_DATA,
   FIELD_SET_HEADER_FAKE_DATA,
   JSON_SCHEMA_COLLECTION_FIELD_FAKE_DATA,
+  JSON_SCHEMA_DATE_TIME_FIELD_SETS,
   JSON_SCHEMA_DEFAULT_VALUES,
+  JSON_SCHEMA_DUPLICATED_CHOICES_SINGLE_SELECT_FAKE_DATA,
   JSON_SCHEMA_EMPTY_CHOICES_FAKE_DATA,
   JSON_SCHEMA_FIELD_SETS_FAKE_DATA,
   JSON_SCHEMA_ID_$SCHEMA_FAKE_DATA,
@@ -14,6 +16,7 @@ import {
   JSON_SCHEMA_INVALID_DEFINITION_LOCATION_FAKE_DATA,
   JSON_SCHEMA_INVALID_DOUBLE_QUOTES_FAKE_DATA,
   JSON_SCHEMA_SPECIAL_CHARS_FAKE_DATA,
+  UI_SCHEMA_ELEMENT_DATE_TIME_FIELD_SETS,
 } from "../common/mockData/formatterMockData"
 import expectedSchema from "../common/mockData/jsonSchemaExpectedMock.json";
 import jsonSchemaFieldSets from "../common/mockData/jsonSchemaFielSetMock.json";
@@ -82,6 +85,10 @@ describe("JSON Schema validation", () => {
   it("Validate remove disabled fieldset titleMap choices", () => {
     const validSchema = validateJSONSchema(JSON_SCHEMA_INACTIVE_FIELD_SET_TITLE_MAP_FAKE_DATA);
     expect(validSchema.schema.properties.reportorigin.items.enum).not.toContain("phot_evidence_collected");
+  });
+
+  it('Validate duplicated items in single select',  () => {
+    expect(() => validateJSONSchema(JSON_SCHEMA_DUPLICATED_CHOICES_SINGLE_SELECT_FAKE_DATA)).toThrow('Duplicated items');
   });
 
   it("Format schema definition location", () => {
@@ -166,6 +173,12 @@ describe("JSON UI Schema generation", () => {
     const uiSchema = generateUISchema(validSchema);
     expect(uiSchema).toMatchObject(expectedUISchema);
   });
+
+    it('Validate UI schema date-time fieldset property',  () => {
+      const validSchema = validateJSONSchema(JSON_SCHEMA_DATE_TIME_FIELD_SETS);
+      const uiSchema = generateUISchema(validSchema);
+      expect(uiSchema.elements[0]).toMatchObject(UI_SCHEMA_ELEMENT_DATE_TIME_FIELD_SETS)
+    });
 
   it("Generate UI Schema for field sets", () => {
     const validSchema = validateJSONSchema(JSON.stringify(jsonSchemaFieldSets));

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "webpack.config.tsx",
+    ".eslintrc.cjs",
+    "src/**/*",
+    "tests/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,26 @@
 {
   "compilerOptions": {
-    /* Basic Options */
     "noImplicitAny": true,
     "module": "es6",
     "target": "es5",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src",
+    "outDir": "./dist",
+    "rootDir": ".",
     "isolatedModules": true,
     "allowJs": true,
-
-    /* Module Resolution Options */
     "moduleResolution": "node",
-    "types": ["node", "jest"],
+    "paths": {
+      "*": [
+        "./src/*",
+        "./test/*"
+      ]
+    },
+    "types": [
+      "node",
+      "jest"
+    ],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -26,9 +32,14 @@
     }
   },
   "include": [
-    "src"
+    "src/**/*",
+    "test/**/*"
   ],
   "exclude": [
-    "node_modules", "babel.config.cjs", "metro.config.js", "jest.config.js"
+    "node_modules",
+    "babel.config.cjs",
+    "metro.config.js",
+    "jest.config.js",
+    "common/**/*"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "test/JsonFormatter.test.tsx"
+  ]
+}

--- a/webpack.config.tsx
+++ b/webpack.config.tsx
@@ -1,15 +1,15 @@
-const path = require('path');
-const webpack = require('webpack');
+const path = require("path");
+const webpack = require("webpack");
 
 const config = {
-  mode: 'production',
+  mode: "production",
   entry: {
-    index: './src/index.ts',
+    index: "./src/index.ts",
   },
   output: {
-    filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist'),
-    libraryTarget: 'commonjs2',
+    filename: "bundle.js",
+    path: path.resolve(__dirname, "dist"),
+    libraryTarget: "commonjs2",
     clean: true,
   },
   module: {
@@ -18,18 +18,19 @@ const config = {
         test: /\.tsx?$/,
         use: [
           {
-            loader: 'ts-loader',
+            loader: "ts-loader",
             options: {
-              configFile: 'tsconfig.json',
+              configFile: "tsconfig.json",
             },
           },
         ],
-        include: [path.resolve(__dirname, 'src')],
+        include: [path.resolve(__dirname, "src")],
+        exclude: [path.resolve(__dirname, "test")],
       },
     ],
   },
   resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
+    extensions: [".tsx", ".ts", ".js"],
   },
   optimization: {
     minimize: true,
@@ -43,19 +44,19 @@ const config = {
   },
   externals: {
     react: {
-      commonjs: 'react',
-      commonjs2: 'react',
-      amd: 'react',
-      root: 'React',
+      commonjs: "react",
+      commonjs2: "react",
+      amd: "react",
+      root: "React",
     },
-    'react-dom': {
-      commonjs: 'react-dom',
-      commonjs2: 'react-dom',
-      amd: 'react-dom',
-      root: 'ReactDOM',
+    "react-dom": {
+      commonjs: "react-dom",
+      commonjs2: "react-dom",
+      amd: "react-dom",
+      root: "ReactDOM",
     },
   },
-  target: 'node',
+  target: "node",
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary
Preferable alternative to `any`, using the safer `unknown`

## Fixes
Extension to eslint question in #13 

## Proposed changes
- Replace all instances of `any` with `unknown`

## Test
- Confirm [message](https://github.com/PADAS/react-native-jsonforms-formatter/pull/13#pullrequestreview-2011887950) references is not longer displaying
- Run all the tests `yarn test`
- Make sure all tests pass 