### PR TITLE
Normalize decimal separators

### DIFF
--- a/common/mockData/formatterMockData.ts
+++ b/common/mockData/formatterMockData.ts
@@ -884,4 +884,81 @@ export const JSON_SCHEMA_DEFAULT_VALUES = '{\n' +
   '      "type": "textarea"\n' +
   '    }\n' +
   '  ]\n' +
+  '}';
+
+export const JSON_SCHEMA_COMMA_DECIMAL_NUMBERS = '{\n' +
+  ' "schema": {\n' +
+  '  "type": "object",\n' +
+  '  "properties": {\n' +
+  '   "price_with_comma": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Price with comma decimal",\n' +
+  '    "default": "12,99",\n' +
+  '    "minimum": "5,50",\n' +
+  '    "maximum": "100,00"\n' +
+  '   },\n' +
+  '   "negative_number": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Negative number with comma",\n' +
+  '    "default": "-15,75"\n' +
+  '   },\n' +
+  '   "regular_number": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Regular number with period",\n' +
+  '    "default": 25.50,\n' +
+  '    "minimum": 0.01\n' +
+  '   },\n' +
+  '   "string_field": {\n' +
+  '    "type": "string",\n' +
+  '    "title": "String field (should not be affected)",\n' +
+  '    "default": "12,99 text"\n' +
+  '   }\n' +
+  '  }\n' +
+  ' },\n' +
+  ' "definition": [\n' +
+  '  "price_with_comma",\n' +
+  '  "negative_number",\n' +
+  '  "regular_number",\n' +
+  '  "string_field"\n' +
+  ' ]\n' +
+  '}';
+
+export const JSON_SCHEMA_EDGE_CASE_NUMBERS = '{\n' +
+  ' "schema": {\n' +
+  '  "type": "object",\n' +
+  '  "properties": {\n' +
+  '   "thousands_separator": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Number with thousands separator (should not convert)",\n' +
+  '    "default": "1.234,56"\n' +
+  '   },\n' +
+  '   "multiple_commas": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Multiple commas (should not convert)",\n' +
+  '    "default": "1,234,567"\n' +
+  '   },\n' +
+  '   "empty_default": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Empty default",\n' +
+  '    "default": ""\n' +
+  '   },\n' +
+  '   "null_default": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Null default",\n' +
+  '    "default": null\n' +
+  '   },\n' +
+  '   "zero_comma": {\n' +
+  '    "type": "number",\n' +
+  '    "title": "Zero with comma",\n' +
+  '    "default": "0,00"\n' +
+  '   }\n' +
+  '  }\n' +
+  ' },\n' +
+  ' "definition": [\n' +
+  '  "thousands_separator",\n' +
+  '  "multiple_commas",\n' +
+  '  "empty_default",\n' +
+  '  "null_default",\n' +
+  '  "zero_comma"\n' +
+  ' ]\n' +
   '}'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthranger/react-native-jsonforms-formatter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "description": "Converts JTD into JSON Schema ",
   "main": "./dist/bundle.js",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -93,6 +93,44 @@ export const isSchemaFieldSet = (definition: any[]) => {
 
 export const isString = (item: any) => typeof item === STRING_TYPE;
 
+export const normalizeDecimalSeparators = (value: string | number): string | number => {
+  // If it's already a number, return as-is
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  // If it's not a string, return as-is
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  // Trim whitespace
+  const trimmedValue = value.trim();
+
+  // If empty string, return as-is
+  if (trimmedValue === '') {
+    return value;
+  }
+
+  // Check if it looks like a number with comma decimal separator
+  // Pattern: optional minus, digits, comma, digits (e.g., "12,34", "-5,678")
+  const commaDecimalPattern = /^-?\d+,\d+$/;
+
+  if (commaDecimalPattern.test(trimmedValue)) {
+    // Replace comma with period for decimal separator
+    const normalizedValue = trimmedValue.replace(',', '.');
+    
+    // Validate that the result is a valid number
+    const numValue = parseFloat(normalizedValue);
+    if (!isNaN(numValue)) {
+      return normalizedValue;
+    }
+  }
+
+  // Return original value if no conversion needed or possible
+  return value;
+};
+
 // Helper function to recursively traverse and process the schema
 export const traverseSchema = (
   schema: any,


### PR DESCRIPTION
## Summary
Handle comma decimal separators in JSON Schema number fields

## Fixes
#17 

## Proposed changes
1. Utility Function (normalizeDecimalSeparators):
    - Converts comma decimal separators to periods (e.g., "12,99" → "12.99")
    - Handles negative numbers ("-15,75" → "-15.75")
    - Safely ignores non-numeric strings, numbers, and complex formats
    - Uses strict regex pattern (/^-?\d+,\d+$/) to only convert simple decimal commas
  2. Integration (normalizeNumberFields):
    - Automatically processes all number fields in schema during validation
    - Normalizes default, minimum, and maximum values
    - Uses traverseSchema to handle nested objects
  3. Validation Pipeline:
    - Integrated into validateJSONSchema before other validation steps
    - Preserves all existing functionality

## Test
- Run all the tests `yarn test`
- Make sure all tests pass 