### PR TITLE
Default checkbox in fieldset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earthranger/react-native-jsonforms-formatter",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.8",
   "description": "Converts JTD into JSON Schema ",
   "main": "./dist/bundle.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Description


## Fixes
#30 

## Proposed Changes
- Update `getSchemaForCheckbox` function
  - If not required: default to empty array
  - If required: no default (null is valid)

## Testing
- Run `yarn test`
  - Verify all tests pass
- Build and link library in React Native app
 
```
# build
npm run build

# link
yarn link

# In React Native client app, e.g. EarthRanger
yarn remove @earthranger/react-native-jsonforms-formatter@2.0.0-beta.14
yarn link @earthranger/react-native-jsonforms-formatter@2.0.0-beta.17
```