### PR TITLE
Support array type in v2 Attachment field

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -39,7 +39,7 @@ export interface V2BaseProperty {
   default?: any;
   minimum?: number;
   maximum?: number;
-  format?: 'date-time' | 'date' | 'time' | 'uri';
+  format?: 'date-time' | 'date' | 'time' | 'uri' | 'uuid';
   anyOf?: Array<
     | { $ref: string }
     | { oneOf: Array<{ const: any; title?: string }> }
@@ -50,6 +50,7 @@ export interface V2BaseProperty {
   required?: string[];
   additionalProperties?: boolean;
   unevaluatedItems?: boolean;
+  unevaluatedProperties?: boolean;
   maxItems?: number;
   minItems?: number;
   uniqueItems?: boolean;

--- a/src/v2/generateUISchema.ts
+++ b/src/v2/generateUISchema.ts
@@ -60,6 +60,19 @@ const validateV2Schema = (schema: V2Schema): void => {
         invalidFields.push(`${fieldName}: CHOICE_LIST field requires embedded oneOf or enum arrays - $ref not supported`);
       }
     }
+
+    if (uiField.type === 'ATTACHMENT') {
+      const hasItemKey =
+        property.items?.properties !== undefined &&
+        Object.keys(property.items.properties).length > 0;
+      const hasRequired =
+        Array.isArray(property.items?.required) &&
+        property.items!.required!.length > 0;
+
+      if (property.type !== 'array' || !hasItemKey || !hasRequired) {
+        invalidFields.push(`${fieldName}: ATTACHMENT field requires an array type with items.properties and items.required`);
+      }
+    }
   });
 
   // Validate section conditions

--- a/src/v2/utils.ts
+++ b/src/v2/utils.ts
@@ -160,7 +160,9 @@ export const createControl = (
         if (property.uniqueItems) {
           control.options!.uniqueItems = true;
         }
-        const itemKey = Object.keys(property.items?.properties ?? {})[0];
+        const itemKey =
+          property.items?.required?.[0] ??
+          Object.keys(property.items?.properties ?? {})[0];
         if (itemKey) {
           control.options!.itemKey = itemKey;
         }

--- a/src/v2/utils.ts
+++ b/src/v2/utils.ts
@@ -144,12 +144,29 @@ export const createControl = (
       }
       break;
 
-    case "ATTACHMENT":
+    case "ATTACHMENT": {
       control.options!.format = "file";
       if (uiField.allowableFileTypes) {
         control.options!.accept = uiField.allowableFileTypes.join(",");
       }
+      if (property.type === "array") {
+        control.options!.multi = true;
+        if (property.maxItems !== undefined) {
+          control.options!.maxItems = property.maxItems;
+        }
+        if (property.minItems !== undefined) {
+          control.options!.minItems = property.minItems;
+        }
+        if (property.uniqueItems) {
+          control.options!.uniqueItems = true;
+        }
+        const itemKey = Object.keys(property.items?.properties ?? {})[0];
+        if (itemKey) {
+          control.options!.itemKey = itemKey;
+        }
+      }
       break;
+    }
   }
 
   // Add description if available

--- a/test/v2.test.ts
+++ b/test/v2.test.ts
@@ -977,6 +977,249 @@ describe('BOOLEAN field type', () => {
   });
 });
 
+// ─── ATTACHMENT field type ───────────────────────────────────────────────────
+
+describe('ATTACHMENT field type', () => {
+  const attachmentSchema: V2Schema = {
+    json: {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      additionalProperties: false,
+      properties: {
+        photo: {
+          deprecated: false,
+          title: 'Attachment Field',
+          description: 'Upload files',
+          type: 'array',
+          uniqueItems: true,
+          minItems: 0,
+          maxItems: 5,
+          items: {
+            type: 'object',
+            properties: {
+              uploadId: {
+                format: 'uuid',
+                type: 'string',
+              },
+            },
+            required: ['uploadId'],
+            unevaluatedProperties: false,
+          },
+        },
+      },
+      required: [],
+      type: 'object',
+    },
+    ui: {
+      fields: {
+        photo: {
+          type: 'ATTACHMENT',
+          parent: 'section-1',
+          allowableFileTypes: ['image'],
+        },
+      },
+      headers: {},
+      order: ['section-1'],
+      sections: {
+        'section-1': {
+          columns: 1,
+          isActive: true,
+          label: 'Attachments',
+          leftColumn: [{ name: 'photo', type: 'field' }],
+          rightColumn: [],
+        },
+      },
+    },
+  };
+
+  it('generates a file control with array semantics', () => {
+    const result = generateUISchema(attachmentSchema);
+    const control = result.elements![0].elements![0];
+    expect(control).toMatchObject({
+      type: 'Control',
+      scope: '#/properties/photo',
+      label: 'Attachment Field',
+      options: {
+        format: 'file',
+        multi: true,
+        maxItems: 5,
+        minItems: 0,
+        uniqueItems: true,
+        itemKey: 'uploadId',
+        accept: 'image',
+        description: 'Upload files',
+      },
+    });
+  });
+
+  it('omits maxItems/minItems when not declared', () => {
+    const schema: V2Schema = {
+      ...attachmentSchema,
+      json: {
+        ...attachmentSchema.json,
+        properties: {
+          photo: (() => {
+            const { minItems, maxItems, ...rest } = attachmentSchema.json.properties.photo;
+            return rest;
+          })(),
+        },
+      },
+    };
+    const result = generateUISchema(schema);
+    const control = result.elements![0].elements![0];
+    expect(control.options).toMatchObject({
+      format: 'file',
+      multi: true,
+      uniqueItems: true,
+      itemKey: 'uploadId',
+    });
+    expect(control.options!.maxItems).toBeUndefined();
+    expect(control.options!.minItems).toBeUndefined();
+  });
+
+  it('joins multiple allowableFileTypes into accept', () => {
+    const schema: V2Schema = {
+      ...attachmentSchema,
+      ui: {
+        ...attachmentSchema.ui,
+        fields: {
+          photo: {
+            ...attachmentSchema.ui.fields.photo,
+            allowableFileTypes: ['image', 'document'],
+          },
+        },
+      },
+    };
+    const result = generateUISchema(schema);
+    const control = result.elements![0].elements![0];
+    expect(control.options!.accept).toBe('image,document');
+  });
+
+  it('supports ATTACHMENT inside a COLLECTION', () => {
+    const schema: V2Schema = {
+      json: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        required: [],
+        type: 'object',
+        properties: {
+          arrests: {
+            deprecated: false,
+            title: 'Arrests',
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { title: 'Name', type: 'string' },
+                arrestee_photo: {
+                  title: 'Arrestee Photo',
+                  type: 'array',
+                  uniqueItems: true,
+                  maxItems: 3,
+                  items: {
+                    type: 'object',
+                    properties: { uploadId: { format: 'uuid', type: 'string' } },
+                    required: ['uploadId'],
+                    unevaluatedProperties: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      ui: {
+        fields: {
+          arrests: {
+            type: 'COLLECTION',
+            parent: 'section-1',
+            buttonText: 'Add Arrest',
+            leftColumn: ['arrests.name', 'arrests.arrestee_photo'],
+            rightColumn: [],
+          },
+          'arrests.name': {
+            type: 'TEXT',
+            inputType: 'SHORT_TEXT',
+            parent: 'arrests',
+          },
+          'arrests.arrestee_photo': {
+            type: 'ATTACHMENT',
+            parent: 'arrests',
+            allowableFileTypes: ['image'],
+          },
+        },
+        headers: {},
+        order: ['section-1'],
+        sections: {
+          'section-1': {
+            columns: 1,
+            isActive: true,
+            label: 'Arrests',
+            leftColumn: [{ name: 'arrests', type: 'field' }],
+            rightColumn: [],
+          },
+        },
+      },
+    };
+
+    const result = generateUISchema(schema);
+    const collectionControl = result.elements![0].elements![0];
+    const detail = collectionControl.options!.detail;
+    const photoControl = detail!.elements![1];
+
+    expect(photoControl).toMatchObject({
+      type: 'Control',
+      scope: '#/properties/arrestee_photo',
+      label: 'Arrestee Photo',
+      options: {
+        format: 'file',
+        multi: true,
+        maxItems: 3,
+        uniqueItems: true,
+        itemKey: 'uploadId',
+        accept: 'image',
+      },
+    });
+  });
+
+  it('throws when an ATTACHMENT field is not an array', () => {
+    const schema: V2Schema = {
+      ...attachmentSchema,
+      json: {
+        ...attachmentSchema.json,
+        properties: {
+          photo: {
+            deprecated: false,
+            title: 'Bad Attachment',
+            type: 'string',
+          },
+        },
+      },
+    };
+    expect(() => generateUISchema(schema)).toThrow(/ATTACHMENT field requires an array type/);
+  });
+
+  it('throws when an ATTACHMENT array lacks items.required', () => {
+    const schema: V2Schema = {
+      ...attachmentSchema,
+      json: {
+        ...attachmentSchema.json,
+        properties: {
+          photo: {
+            deprecated: false,
+            title: 'Bad Attachment',
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { uploadId: { format: 'uuid', type: 'string' } },
+            },
+          },
+        },
+      },
+    };
+    expect(() => generateUISchema(schema)).toThrow(/ATTACHMENT field requires an array type/);
+  });
+});
+
 // ─── enum + x-enumExtra (issue #41) ──────────────────────────────────────────
 
 const enumChoiceSchema: V2Schema = {

--- a/test/v2.test.ts
+++ b/test/v2.test.ts
@@ -1094,6 +1094,35 @@ describe('ATTACHMENT field type', () => {
     expect(control.options!.accept).toBe('image,document');
   });
 
+  it('derives itemKey from items.required, not property declaration order', () => {
+    const schema: V2Schema = {
+      ...attachmentSchema,
+      json: {
+        ...attachmentSchema.json,
+        properties: {
+          photo: {
+            deprecated: false,
+            title: 'Attachment Field',
+            type: 'array',
+            items: {
+              type: 'object',
+              // caption declared first, but uploadId is the binding (required) key
+              properties: {
+                caption: { type: 'string' },
+                uploadId: { format: 'uuid', type: 'string' },
+              },
+              required: ['uploadId'],
+              unevaluatedProperties: false,
+            },
+          },
+        },
+      },
+    };
+    const result = generateUISchema(schema);
+    const control = result.elements![0].elements![0];
+    expect(control.options!.itemKey).toBe('uploadId');
+  });
+
   it('supports ATTACHMENT inside a COLLECTION', () => {
     const schema: V2Schema = {
       json: {


### PR DESCRIPTION
Add support for #42

## Proposed Changes

- Update `ATTACHMENT` case with array support
- Updated the typed model to support `uuid` format
- Update tests

## Implementation Test

**In React Native client app, e.g. EarthRanger**

```
- yarn remove @earthranger/react-native-jsonforms-formatter
- yarn add @earthranger/react-native-jsonforms-formatter@2.0.0-beta.33
```

## Unit Tests

```bash
 PASS  test/v2.test.ts
  V2 generateUISchema
    ✓ should generate UI schema for basic V2 schema (2 ms)
    ✓ should create controls with proper scopes and labels
    ✓ should handle text field options correctly (1 ms)
    ✓ should handle numeric field options correctly
    ✓ should handle choice list field options correctly
    ✓ should handle date-time field options correctly
    ✓ should handle location field options correctly
    ✓ should handle collection field options correctly (1 ms)
    ✓ should exclude deprecated fields
    ✓ should handle inactive sections
    ✓ should respect section order
    ✓ should handle collection constraints and column layout (1 ms)
    ✓ should handle single column sections correctly
    ✓ should handle two column sections correctly (React Native single-column)
    ✓ should apply UI field properties to collection item fields
    ✓ should resolve same-named fields at different nesting levels using qualified ids (1 ms)
    ✓ should not apply a top-level field config to a collection child when the section id matches the collection local name
    ✓ should handle old-format schema where collection child shares name with parent collection
    ✓ should handle doubly-nested collections with shared field names (Nested.Nest_1.Nest_Text) (1 ms)
    ✓ should support nested collections (collection within collection)
  BOOLEAN field type
    ✓ generates a Control with boolean format
    ✓ includes the description in options
    ✓ deprecated boolean field is not rendered (1 ms)
  ATTACHMENT field type
    ✓ generates a file control with array semantics
    ✓ omits maxItems/minItems when not declared
    ✓ joins multiple allowableFileTypes into accept
    ✓ supports ATTACHMENT inside a COLLECTION
    ✓ throws when an ATTACHMENT field is not an array (6 ms)
    ✓ throws when an ATTACHMENT array lacks items.required (2 ms)
  V2 generateUISchema — enum + x-enumExtra format (issue #41)
    ✓ accepts single-select CHOICE_LIST with enum format without throwing
    ✓ accepts multi-select CHOICE_LIST with enum format on items without throwing
    ✓ generates dropdown control for single-select enum field with placeholder
    ✓ injects options.oneOf with display titles for single-select enum field
    ✓ generates multi dropdown control for array enum field with placeholder
    ✓ injects options.oneOf with display titles for multi-select array enum field (1 ms)
    ✓ falls back to raw enum value as title when x-enumExtra is missing an entry
    ✓ injects options.oneOf using raw values as titles when x-enumExtra is entirely absent
    ✓ does not inject options.oneOf for old-format oneOf schemas (backward compatibility)
    ✓ does not mutate the original schema.json

Test Suites: 1 passed, 1 total
Tests:       39 passed, 39 total
Snapshots:   0 total
Time:        0.307 s, estimated 1 s
```